### PR TITLE
Docs: final sweep per Report.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Pong with Steroids (Foundation)
 
-A modular, vanilla-JS Pong built as the base for a roguelike arcade experience (AI, powers, cards, bosses). Run by opening `index.html`.
+A modular, vanilla-JS Pong built as the base for a roguelite arcade experience (AI, powers, cards, bosses). Run by opening `index.html`.
 
 - Docs for contributors and AI agents are in `docs/`:
   - `docs/README.md` (overview)
   - `docs/ARCHITECTURE.md`
-  - `docs/EXTENSIONS.md`
+  - `docs/MODDING.md`
   - `docs/CONTRIBUTING.md`
   - `docs/ROADMAP.md`
   - `docs/DECISIONS.md`
-  - `docs/CHECKLISTS.md`
-  - `docs/EXAMPLES.md`
+  - `docs/playbooks/CHECKLISTS.md`
+  - `docs/examples/EXAMPLES.md`
   - `docs/README_TLDR.md`

--- a/Report.md
+++ b/Report.md
@@ -1,0 +1,70 @@
+## Documentation Audit Report — Pong with Steroids
+
+Date: 2025-08-10
+
+
+### Critical inconsistencies to fix
+- **Roguelite vs Roguelike (terminology mismatch)**
+  - `docs/design/GAME_DESIGN_OVERVIEW.md` explicitly: “roguelite, not roguelike.”
+  - `README.md` (root) and `docs/README.md`/`docs/ROADMAP.md` say “roguelike.”
+  - **Action**: Standardize on “roguelite.” Update all non-design docs to match the design canon.
+
+- **Card draft size (3 vs 2–3)**
+  - `docs/design/CORE_LOOP.md` and `docs/design/PLAYER_UPGRADES.md`: always 3-card drafts.
+  - `docs/ROADMAP.md` (M4): “present 2–3 cards.”
+  - **Action**: Keep exactly 3 and update `docs/ROADMAP.md` accordingly.
+
+- **Arena name mismatch: “Lights Out” vs “Blackout”**
+  - `docs/design/ARENAS.md`: `ARENA_BLACKOUT` (name “Blackout”).
+  - `docs/design/CARDS_CATALOG.md` Synergies: mentions “Lights Out”.
+  - **Action**: Rename the synergy mentions to “Blackout”.
+
+### Missing files / broken references
+- **Missing file: `docs/EXTENSIONS.md`**
+  - Referenced by: `README.md` (root), `docs/README_TLDR.md`, `docs/CONTRIBUTING.md`, `docs/ARCHITECTURE.md`.
+  - **Action**:  update all references to `docs/MODDING.md`.
+
+- **Wrong paths in root `README.md`**
+  - Points to `docs/CHECKLISTS.md` and `docs/EXAMPLES.md`.
+  - Actual files: `docs/playbooks/CHECKLISTS.md`, `docs/examples/EXAMPLES.md`.
+  - **Action**: Fix the two links in the root `README.md`.
+
+- **Duplicate link**
+  - `docs/design/GAME_DESIGN_OVERVIEW.md` lists `OPPONENTS.md` twice in the Links section.
+  - **Action**: Remove the duplicate entry.
+
+### Clarifications that unblock implementation
+- **Card type semantics and duration**
+  - `Arena Boon`/`Arena Curse` entries are inconsistent: many say “in next match”, others don’t (e.g., `TONGUE_LASH`, `LUCKY_BOUNCE`).
+  - `TONGUE_LASH` is typed as an Arena Boon but functions like a player ability during rallies.
+  - **Action**: In the card schema, add a `Duration:` field (e.g., `Next match only` vs `Until end of run`). Clarify that Arena Boons/Curses are match-scoped modifiers, not persistent, unless explicitly stated.
+
+- **“Cosmetic” vs “Visual” wording**
+  - `GAME_DESIGN_OVERVIEW.md` canon: “cards include trade-offs and cosmetic changes”.
+  - `META_HUB.md`: “There are no purely cosmetic options.”
+  - **Action**: Replace “cosmetic” with “visual” where it coexists with mechanics. E.g., “trade-offs and visual changes (communicating mechanics).”
+
+- **Scoring behavior in special arenas**
+  - `ARENA_POOL_ZONE`: Ball “drowns” and respawns center — unclear whether a point is awarded.
+  - **Action**: Specify “no point; neutral reset” to avoid logic ambiguity.
+
+- **Numeric representation consistency**
+  - Mixed usage of percentages and multipliers across docs (e.g., “+20%” and “speed multiplier = 1.2”).
+  - **Action**: Pick a primary convention and mirror the other in parentheses once. Example: “multiplier 1.2”.
+
+- **Tier naming consistency**
+  - Variants appear: “High-Tier/Boss”, “High-Tier”, “boss-tier”.
+  - **Action**: Normalize to one: e.g., `Lower-Tier`, `Mid-Tier`, `High-Tier (Boss)`.
+
+### Minor issues
+- **Typo**: `docs/design/GAME_DESIGN_OVERVIEW.md` Pillars: “High readabilty” → “High readability”.
+  - **Action**: Fix the typos.
+
+
+### Suggested additions (nice-to-have for agents)
+- **RNG/Seeding policy**: State if runs are seedable and how seeds are surfaced (e.g., debug overlay, URL param). This aids repro and automated testing.
+- **Glossary**: Short section defining common terms: paddle length/width, paddle movement speed, rebound speed, curve/spin, serve.
+- **Balance notes template**: Add a starter entry format example under `docs/design/BALANCE_NOTES.md`.
+
+
+— End of report —

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,7 +32,7 @@ Extend state by adding new fields (e.g., `rng`, `mode`, `effects`) but keep init
 ## Game Loop
 - Fixed-step `dt = 1/60` with accumulator; prevents variable update rates.
 - Update order (intentional): Input → AI → Entities → Physics → Scoring → Render.
-- Extension points are between these phases (see `EXTENSIONS.md`).
+- Extension points are between these phases (see `MODDING.md`).
 
 ## Rendering
 - `renderer.js` exposes:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -43,4 +43,4 @@ Guidelines to keep the codebase consistent, readable, and extensible.
 
 ## Definition of Done
 - Code follows the above discipline and passes manual tests.
-- New modules are documented briefly in `docs/EXTENSIONS.md` or inline with concise docstrings.
+- New modules are documented briefly in `docs/MODDING.md` or inline with concise docstrings.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 This document orients future contributors and AI agents to extend this codebase cleanly. It summarizes goals, constraints, structure, and the core loop.
 
 ## Goals
-- Build a modular, extensible foundation for a roguelike Pong (AI opponents, powers, levels, cards).
+- Build a modular, extensible foundation for a roguelite Pong (AI opponents, powers, levels, cards).
 - Keep the main loop clean; isolate concerns per module.
 - Prefer readability and maintainability over micro-optimizations.
 

--- a/docs/README_TLDR.md
+++ b/docs/README_TLDR.md
@@ -6,5 +6,5 @@
 - Respect and extend `state` via `core/state.js`.
 - Physics mutates entities; it does not render.
 - AI lives under `src/ai/` and only controls behaviors.
-- Use `docs/EXTENSIONS.md` for recipes.
+- Use `docs/MODDING.md` for recipes.
 - Keep it readable; optimize last.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Milestones to evolve classic Pong into a roguelike arcade experience.
+Milestones to evolve classic Pong into a roguelite arcade experience.
 
 ## M1: Core Polish
 - Ball/paddle polish: edge cases, speed capping, angle tuning
@@ -18,7 +18,7 @@ Milestones to evolve classic Pong into a roguelike arcade experience.
 - Level progression with themed parameters and win/lose conditions
 
 ## M4: Card Drafts & Meta
-- Between rounds, present 2–3 cards (canvas UI)
+- Between rounds, present 3 cards (canvas UI)
 - Card effects stack; persist temporary run state
 - Add simple meta-progression saved to `localStorage`
 

--- a/docs/design/ARENAS.md
+++ b/docs/design/ARENAS.md
@@ -21,7 +21,7 @@ Define the biome-style arenas, their environmental effects, and design rules for
   - Build contrast for later, more chaotic arenas.
   - Reinforce the story’s early-game “boring void” tone.
 - **Mid-Tier Arenas:** Introduce one significant, readable modifier.
-- **High-Tier/Boss Arenas:** Strong, often chaotic effects; can combine multiple modifiers.
+- **High-Tier (Boss) Arenas:** Strong, often chaotic effects; can combine multiple modifiers.
 - Arena effects must:
   - Be visually communicated to the player.
   - Interact with the ball, paddle, or both.
@@ -88,7 +88,7 @@ Define the biome-style arenas, their environmental effects, and design rules for
 
 #### ID: ARENA_PARTY_ZONE
 - **Name:** Party Zone
-- **Tier:** High-Tier/Boss
+- **Tier:** High-Tier (Boss)
 - **Effect:** Lights strobe and colors shift rapidly; occasional full-screen flashes.
 - **Visuals:** Disco-style background, pulsing floor.
 - **Numerics:** Lighting change rate = 0.5–1.5s intervals.
@@ -100,11 +100,11 @@ Define the biome-style arenas, their environmental effects, and design rules for
 - **Effect:** A waterline occupies the bottom 15% of the screen. When the ball hits the water, it “drowns” and a new ball spawns from the center.
 - **Visuals:** Animated water surface with splashes.
 - **Numerics:** Waterline height = 15% screen height; splash animation 0.3s.
-- **Notes:** Changes player strategy for low hits; increases randomness.
+- **Notes:** Changes player strategy for low hits; increases randomness. Scoring: No point is awarded; the ball is reset to center (neutral serve).
 
 #### ID: ARENA_ZERO_G
 - **Name:** Zero-G Chamber
-- **Tier:** High-Tier/Boss
+- **Tier:** High-Tier (Boss)
 - **Effect:** Reduced gravity makes balls bounce higher and stay in play longer.
 - **Visuals:** Floating debris, low-gravity ball arcs.
 - **Numerics:** Gravity scale = 40% of default; ball air time increased ~1.6×.
@@ -112,7 +112,7 @@ Define the biome-style arenas, their environmental effects, and design rules for
 
 #### ID: ARENA_BLACKOUT
 - **Name:** Blackout
-- **Tier:** High-Tier/Boss
+- **Tier:** High-Tier (Boss)
 - **Effect:** Lights periodically go out, hiding paddles, ball, and arena.
 - **Visuals:** Full darkness with occasional sparks or flashes revealing positions.
 - **Numerics:** Darkness lasts 1s; visible phase lasts 4s.
@@ -120,7 +120,7 @@ Define the biome-style arenas, their environmental effects, and design rules for
 
 #### ID: ARENA_ARCHIVE_STACK
 - **Name:** Archive Stack
-- **Tier:** High-Tier/Boss
+- **Tier:** High-Tier (Boss)
 - **Effect:** **Playback Tracks.** Three faint horizontal “tape tracks” (at 25%, 50%, 75% screen height) record the ball’s vector when it crosses them and “stamp” it for a short window. If the ball crosses the *same* track again while a stamp is active, its outgoing angle **snaps to the stamped vector** (Pattern Replay) at 90% of current speed, overriding normal contact angle for that bounce only. While the ball travels within 12px of a track, a mild **tape drag** curves its path by up to ±6° along the track.
 - **Visuals:** Twin tape reels turning in the background; the active track glows with a timecode tick. When a vector is stamped, a short ghost-arrow sits on the track showing the stored angle; on replay, the arrow “rewinds” and the ball follows it for a beat.
 - **Numerics:** Track positions = 25% / 50% / 75% screen height; stamp lifetime = 3.0s; replay speed multiplier = 0.9; tape-drag curvature = up to ±6° within 12px radius; per-track replay cooldown = 5s; disabled during serves and for 0.5s after a point.

--- a/docs/design/CARDS_CATALOG.md
+++ b/docs/design/CARDS_CATALOG.md
@@ -14,6 +14,7 @@ Use per-card blocks:
 - **Name:** <Readable Name>
 - **Type:** Paddle Upgrade | Ball Modifier | Arena Boon | Curse
 - **Rarity:** Common/Uncommon/Rare/Legendary
+- **Duration:** Next match only | Persistent this run | Other (specify)
 - **Effect:** <Exact effect>
 - **Trade-off:** <Exact trade-off or “None”>
 - **Numerics:** <All tunables with default values>
@@ -27,7 +28,7 @@ Use per-card blocks:
 * **Common:** Accessible from match 1; simple stat shifts with mild trade-offs.
 * **Uncommon:** Appear from match 2 onward; introduce moderate ability twists.
 * **Rare:** Appear from match 3 onward; more complex effects, often unlocked via specific opponent defeats.
-* **Legendary:** Appear from match 5 onward; highly impactful, unique synergies, require boss-tier unlocks.
+* **Legendary:** Appear from match 5 onward; highly impactful, unique synergies, require High-Tier (Boss) unlocks.
 
 ## Paddle Upgrades
 
@@ -41,7 +42,7 @@ Use per-card blocks:
 * **Numerics:** Curve strength radius = 120px; length reduction = 10%.
 * **Synergies:** Boom Ball, Slow Time.
 * **Visuals:** Subtle shimmering field around paddle.
-* **Unlock:** Defeat any Mid-tier boss.
+* **Unlock:** Defeat any Mid-Tier (Boss).
 * **Notes:** Strong in control builds; loses reach in corners.
 
 ### ID: TURBO_BOOST
@@ -92,7 +93,7 @@ Use per-card blocks:
 - **Numerics:** Extension multiplier = 1.25; extension duration = 1s; cooldown = 6s; speed multiplier = 0.95.
 - **Synergies:** Turbo Boost, Sticky Floor.
 - **Visuals:** Paddle briefly elongates with a stretching animation.
-- **Unlock:** Defeat any Mid-tier boss.
+- **Unlock:** Defeat any Mid-Tier (Boss).
 - **Notes:** Timing-based reach advantage.
 
 ### ID: SLOW_TIME
@@ -222,7 +223,7 @@ Use per-card blocks:
 * **Numerics:** Spin variance ±20°.
 * **Synergies:** Windy Zone, Kamaleon.
 * **Visuals:** Ball trail shifts color based on spin direction.
-* **Unlock:** Defeat two High-tier bosses in a single run.
+* **Unlock:** Defeat two High-Tier (Boss) opponents in a single run.
 * **Notes:** High-skill, high-risk.
 
 ### ID: FIREBALL
@@ -292,6 +293,8 @@ Use per-card blocks:
 
 ## Arena Boons / Curses
 
+Note on scope: Unless otherwise specified, Arena Boons and Arena Curses apply to the next match only.
+
 ### ID: STICKY_FLOOR
 
 * **Name:** Sticky Floor
@@ -310,6 +313,7 @@ Use per-card blocks:
 - **Name:** Tongue Lash
 - **Type:** Arena Boon
 - **Rarity:** Legendary
+- **Duration:** Next match only
 - **Effect:** When the ball is within 0.5 paddle lengths of your back wall (about to concede a point), you may instantly “catch” it and relaunch it into play from your paddle’s current position. The relaunch can alter the ball’s angle by up to ±20° toward the opponent’s side.
 - **Trade-off:** 30s cooldown between uses (player). AI opponents may only use this ability once per match.
 - **Numerics:** Catch trigger distance = 0.5 paddle lengths; cooldown = 30s (player); AI limit = 1 use per match; relaunch speed = 90% of ball’s incoming speed; angle adjustment range = ±20°.
@@ -354,7 +358,7 @@ Use per-card blocks:
 * **Numerics:** Speed multiplier = 1.2; time penalty = −1 point per 25s continuous rally.
 * **Synergies:** Fireball, Chaos Spin.
 * **Visuals:** Red glow intensifies as penalty approaches.
-* **Unlock:** Defeat any Mid-tier boss.
+* **Unlock:** Defeat any Mid-Tier (Boss) opponent.
 * **Notes:** Forces aggressive, point-ending plays.
 
 ### ID: HEAVY_GRAVITY
@@ -429,7 +433,7 @@ Use per-card blocks:
 * **Effect:** Adds semi-transparent fog overlay to arena.
 * **Trade-off:** Both paddles move −5% speed.
 * **Numerics:** Visibility reduction = \~30%; paddle speed multiplier = 0.95.
-* **Synergies:** Lights Out, Camo Sphere.
+* **Synergies:** Blackout, Camo Sphere.
 * **Visuals:** Animated fog drifting.
 * **Unlock:** Default pool.
 * **Notes:** Reduces readability for both players.
@@ -438,7 +442,7 @@ Use per-card blocks:
 - **Name:** Lucky Bounce
 - **Type:** Arena Boon
 - **Rarity:** Rare
-- **Effect:** First paddle hit each rally redirects ball toward opponent’s corner with +10° angle bias.
+- **Effect:** In the next match, the first paddle hit each rally redirects the ball toward the opponent’s corner with +10° angle bias.
 - **Trade-off:** Your paddle rebound speed −5%.
 - **Numerics:** Angle shift = +10°; rebound speed multiplier = 0.95.
 - **Synergies:** Magnet Paddle, Chaos Spin.

--- a/docs/design/CORE_LOOP.md
+++ b/docs/design/CORE_LOOP.md
@@ -53,15 +53,15 @@ A single run consists of:
 ### Match Rules & Championship Structure
 - **Points to Win a Match:** First player to score **6 points** wins.
 - **Championship Format:** A run consists of **7 matches** total.
-  - Matches 1–2: Lower-tier opponents, mild arena effects.
-  - Matches 3–4: Mid-tier opponents, moderate arena effects.
-  - Matches 5–7: High-tier/boss opponents, extreme arena effects.
+  - Matches 1–2: Lower-Tier opponents, mild arena effects.
+  - Matches 3–4: Mid-Tier opponents, moderate arena effects.
+  - Matches 5–7: High-Tier (Boss) opponents, extreme arena effects.
 - **Progression:** Player must win all 7 matches in a row to become Champion.
 
 ---
 
 ### Progression Rules
-- Defeating **new High-tier/boss opponents** = unlocks new, more powerful card types.
+- Defeating **new High-Tier (Boss) opponents** unlocks new, more powerful card types.
 - Certain deaths unlock new dialog lines or hub interactions.
 - Arena variety ensures each run feels distinct.
 

--- a/docs/design/GAME_DESIGN_OVERVIEW.md
+++ b/docs/design/GAME_DESIGN_OVERVIEW.md
@@ -10,12 +10,12 @@ Never invent new mechanics not listed here without adding them to GAME_DESIGN_OV
 One-page map of the game vision, pillars, win/lose conditions, meta-progression philosophy, and links to detailed design docs.
 ## Pillars
 - Pong Core, Roguelite Spice
-- High readabilty, escalating chaos
+- High readability, escalating chaos
 - Meaningful trade-offs over raw power
 ## Canon
 - Run-based structure with meta-progression (roguelite, not roguelike)
 - Every match = arena + opponent + ball modifier
-- 3-card draft after matches; cards include trade-offs and cosmetic changes
+- 3-card draft after matches; cards include trade-offs and visual changes
 ## Links
 - [STORY_LORE.md](./STORY_LORE.md)
 - [CORE_LOOP.md](./CORE_LOOP.md)
@@ -24,5 +24,4 @@ One-page map of the game vision, pillars, win/lose conditions, meta-progression 
 - [ARENAS.md](./ARENAS.md)
 - [META_HUB.md](./META_HUB.md)
 - [CARDS_CATALOG.md](./CARDS_CATALOG.md)
-- [OPPONENTS.md](./OPPONENTS.md)
 - [BALANCE_NOTES.md](./BALANCE_NOTES.md)

--- a/docs/design/META_HUB.md
+++ b/docs/design/META_HUB.md
@@ -28,7 +28,7 @@ Define the post-death space where the player prepares for the next run, interact
 
 2. **Post-Death Review**
    - Summary of match performance.
-   - List of new cards unlocked (if a new High-tier/Boss was defeated).
+   - List of new cards unlocked (if a new High-Tier (Boss) opponent was defeated).
    - Updated opponent/arena intel.
 
 3. **Currency Spending**
@@ -54,7 +54,7 @@ Define the post-death space where the player prepares for the next run, interact
 ---
 
 ### Unlock Flow
-- **New Cards:** Unlocked immediately upon first victory over a new High-tier/Boss opponent.
+- **New Cards:** Unlocked immediately upon first victory over a new High-Tier (Boss) opponent.
 - **New Paddle Styles:** Purchased with Ball Bearings after meeting specific performance conditions (e.g., win 3 matches without losing a point).
 
 ---

--- a/docs/design/OPPONENTS.md
+++ b/docs/design/OPPONENTS.md
@@ -15,19 +15,19 @@ Define the philosophy behind opponent design, the rules for creating them, and c
 ## Philosophy & Design Rules
 - Every opponent is a **paddle** with a unique ability or mechanic that changes rally dynamics.
 - Opponents should have **memorable names**, themed abilities, and distinct personalities.
-- High-tier/Boss opponents should feel mechanically and visually distinct from lower-tier opponents.
-- Beating a **new High-tier/Boss opponent** unlocks a new, more powerful card type in the upgrade pool.
+- High-Tier (Boss) opponents should feel mechanically and visually distinct from lower-tier opponents.
+- Beating a **new High-Tier (Boss) opponent** unlocks a new, more powerful card type in the upgrade pool.
 - Opponent abilities must:
   - Interact meaningfully with both the ball and the player’s paddle.
   - Be readable at a glance (clear visual indicators).
-  - Scale in complexity and challenge from lower-tier to boss-tier.
+  - Scale in complexity and challenge from lower-tier to High-Tier (Boss).
 
 ---
 
 ## Tier Guidelines
 - **Lower-Tier:** Simple mechanics, mild difficulty. Introduce player to variety without overwhelming them.
 - **Mid-Tier:** Abilities that require adaptation and strategy; moderate arena effect synergy.
-- **High-Tier/Boss:** Strong, signature abilities; complex attack patterns; often paired with extreme arena effects.
+- **High-Tier (Boss):** Strong, signature abilities; complex attack patterns; often paired with extreme arena effects.
 
 ---
 
@@ -35,7 +35,7 @@ Define the philosophy behind opponent design, the rules for creating them, and c
 
 ### ID: OPP_MIRROR
 - **Name:** Mirror Paddle
-- **Tier:** High-Tier/Boss
+- **Tier:** High-Tier (Boss)
 - **Ability Kit:** Copies all upgrades the player has chosen so far.
 - **Special Rules:** Gains the copied upgrade effects immediately before match start.
 - **Arena Affinity:** Neutral — can appear in any arena.
@@ -66,7 +66,7 @@ Define the philosophy behind opponent design, the rules for creating them, and c
 
 ### ID: OPP_OCTOPUS
 - **Name:** Octopus
-- **Tier:** High-Tier/Boss
+- **Tier:** High-Tier (Boss)
 - **Ability Kit:** Controls 4 smaller paddles linked together; can intercept ball at multiple heights.
 - **Special Rules:** Mini-paddles have reduced length and move slightly slower than main paddle.
 - **Arena Affinity:** Works best in large arenas with multiple ball spawn points.
@@ -105,7 +105,7 @@ Define the philosophy behind opponent design, the rules for creating them, and c
   - Bit Flip cannot trigger twice in a row; 1s lockout.
   - Both abilities are disabled during serves.
 - **Arena Affinity:** Strong in narrow arenas where vertical space is limited, allowing teleports to consistently cover the ball.
-- **Unlocks:** None unique — counts toward “Defeat any Mid-tier boss” unlocks.
+- **Unlocks:** None unique — counts toward “Defeat any Mid-Tier (Boss)” unlocks.
 - **Numerics:**
   - Teleport distance = 0.3 paddle lengths; cooldown = 6–9s random.
   - Bit Flip chance = 15%; lockout = 1s.
@@ -121,7 +121,7 @@ Define the philosophy behind opponent design, the rules for creating them, and c
   - Echo balls are harmless but visually distracting; their trail opacity increases if they pass near your paddle.
   - Sound Burst applies only to real balls, never to echoes.
 - **Arena Affinity:** Best in high-contrast arenas where echoes are hard to visually ignore.
-- **Unlocks:** None unique — counts toward “Defeat any Mid-tier boss” unlocks.
+- **Unlocks:** None unique — counts toward “Defeat any Mid-Tier (Boss)” unlocks.
 - **Numerics:**
   - Echo delay = 1.5s lifespan; speed = 50% of real ball.
   - Sound Burst frequency = every 4th hit; speed multiplier = 1.15.
@@ -138,7 +138,7 @@ Define the philosophy behind opponent design, the rules for creating them, and c
   - Data Corruption does **not** alter ball physics — only visuals — so skilled players can ignore the fake cues, but it’s disorienting.
   - Archivist’s AI prioritizes using Pattern Recall at high ball speeds for maximum pressure.
 - **Arena Affinity:** Excels in arenas with low visual clutter, where Data Corruption is harder to mentally filter out.
-- **Unlocks:** High-tier pool; counts toward “Defeat any High-tier boss” unlocks.
+- **Unlocks:** High-Tier (Boss) pool; counts toward “Defeat any High-Tier (Boss)” unlocks.
 - **Numerics:**
   - Pattern Recall window: stores last 3 player hits (speed, angle, spin); picks one at random.
   - Data Corruption frequency = every 5th hit; visual distortion = 2s.

--- a/docs/design/PLAYER_UPGRADES.md
+++ b/docs/design/PLAYER_UPGRADES.md
@@ -28,7 +28,7 @@ Define the player’s paddle identity, the upgrade acquisition system, and the r
   - **Paddle Upgrades** – Affect size, speed, special abilities.
   - **Ball Modifiers** – Change ball physics, behavior, or interactions.
   - **Arena Boons/Curses** – Affect the playfield during future matches.
-- Defeating a **new High-tier/Boss opponent** unlocks a new, more powerful card type for future runs.
+- Defeating a **new High-Tier (Boss) opponent** unlocks a new, more powerful card type for future runs.
 
 ---
 


### PR DESCRIPTION
- Standardize 'roguelite' terminology and tier naming
- Fix broken/missing links (EXTENSIONS->MODDING, README paths)
- Clarify Arena Boon/Curse scope, add Duration to schema
- Disambiguate ARENA_POOL_ZONE scoring; unify card draft rule
- Resolve 'Blackout' naming and typos; remove duplicate links